### PR TITLE
ci: rename default branch to main

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,7 +1,8 @@
 name: Publish
 on:
   push:
-  pull_request_target:
+    branches:
+      - main
 jobs:
   copy-go:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Ensure we publish from the `main` branch
- Remove old testing `on` conditions