### PR TITLE
ci: update downstream repo target branch

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        dep: [envoy, udpa, validate, xds]
+        dep: [envoy, validate, xds]
     steps:
       - name: Copy generated Python
         uses: andstor/copycat-action@v3

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,6 +15,7 @@ jobs:
           dst_path: /pb/.
           dst_owner: pomerium
           dst_repo_name: enterprise-client-go
+          dst_branch: main
           clean: true
 
   copy-python-deps:
@@ -32,6 +33,7 @@ jobs:
           dst_path: /src/${{ matrix.dep }}/.
           dst_owner: pomerium
           dst_repo_name: enterprise-client-python
+          dst_branch: main
           clean: true
 
   copy-python:
@@ -45,4 +47,5 @@ jobs:
           dst_path: /src/pomerium/pb/.
           dst_owner: pomerium
           dst_repo_name: enterprise-client-python
+          dst_branch: main
           clean: true


### PR DESCRIPTION
copycat action requires the branch to be explicitly set if it isn't `master`

also remove udpa directory from python's copy list