### PR TITLE
chore: update scripts can now reference any tag/sha

### DIFF
--- a/scripts/update
+++ b/scripts/update
@@ -23,9 +23,15 @@ function clone() {
     (cd "$_dst" && git init && git remote add origin "git@github.com:$_name")
   fi
   (
-    cd "$_dst"
-    git fetch --depth=1 origin
-    git switch --force-create dev "$_tag"
+      cd "$_dst"
+      if [[ "$_tag" =~ ^[0-9a-f]{40}$ ]]; then
+          echo "Checking out commit $_tag in $_name"
+          git fetch --depth=1 origin "$_tag"
+      else
+          echo "Checking out tag $_tag in $_name"
+          git fetch origin --depth=1 tag "$_tag" --no-tags
+      fi
+      git switch --force-create dev "$_tag"
   )
 }
 


### PR DESCRIPTION
Tested with old & current commits that changes propagate correctly


Part of : [ENG-2695](https://linear.app/pomerium/issue/ENG-2695/change-enterprise-client-update-scripts-to-function-with-commit-sha)